### PR TITLE
Fix console input, at least for Linux

### DIFF
--- a/src/fake86/console.c
+++ b/src/fake86/console.c
@@ -76,6 +76,10 @@ void waitforcmd (char *dst, uint16_t maxlen) {
 		}
 #else
 	fgets (dst, maxlen, stdin);
+	char *newl = strchr(dst, '\n');
+	if (newl) {
+		*newl = 0;	// wipe out potential-new-line character
+	}
 #endif
 }
 


### PR DESCRIPTION
Current unix (non-WIN32) implementation of console input doesn't take care
of potential newline character at the end of the string returned by fgets().
It thus breaks the console input, at least on linux.

This trivial PR fixes just that.
